### PR TITLE
Accordion & Search Styles

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,15 +1,27 @@
+:root {
+    --accordion-background-color: #00808c;
+    --accordion-color: #a7a7a7;
+    --accordion-title-color: #fff;
+    --accordion-title-padding: 12px;
+    --accordion-border-radius: 6px;
+    --accordion-border-color: #ddd;
+    --accoridon-border: 1px solid var(--accordion-border-color);
+    --accordion-content-background: #ddd;
+    --accordion-content-color: #56585a;
+}
+
 .accordion {
-    background: #00808c;
-    color: #a7a7a7;
-    border: 1px solid #ddd;
-    border-radius: 6px;
+    background: var(--accordion-background-color);
+    color: var(--accordion-color);
+    border: var(--accordion-border);
+    border-radius: var(--accordion-border-radius);
 }
 
 .item-title {
     cursor: pointer;
-    color: #fff;
-    padding: 12px;
-    border-bottom: 1px solid #ddd;
+    color: var(--accordion-title-color);
+    padding: var(--accordion-title-color);
+    border-bottom: var(--accordion-border);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -35,12 +47,12 @@
     grid-template-columns: 1fr 1fr;
     gap: 12px;
     padding: 12px;
-    background: #ddd;
-    border-bottom: 1px solid #ddd;
+    background: var(--accordion-content-background);
+    border-bottom: var(--accordion-border);
 }
 
 .item-content > div {
-    color: #56585a;
+    color: var(--accordion-content-color);
 }
 
 .item-title.open + .item-content {

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,26 +1,26 @@
 :root {
-    --accordion-background-color: #00808c;
-    --accordion-color: #a7a7a7;
-    --accordion-title-color: #fff;
-    --accordion-title-padding: 12px;
+    --accordion-background-color: none;
+    --accordion-color: #57585a;
+    --accordion-title-color: var(--accordion-color);
+    --accordion-title-padding: 8px;
     --accordion-border-radius: 6px;
-    --accordion-border-color: #ddd;
-    --accoridon-border: 1px solid var(--accordion-border-color);
-    --accordion-content-background: #ddd;
+    --accordion-border-color: var(--accordion-color);
+    --accordion-border: 1px solid var(--accordion-color);
+    --accordion-content-background: #fff;
     --accordion-content-color: #56585a;
 }
 
 .accordion {
     background: var(--accordion-background-color);
     color: var(--accordion-color);
-    border: var(--accordion-border);
+    /* border: var(--accordion-border); */
     border-radius: var(--accordion-border-radius);
 }
 
 .item-title {
     cursor: pointer;
     color: var(--accordion-title-color);
-    padding: var(--accordion-title-color);
+    padding: var(--accordion-title-padding);
     border-bottom: var(--accordion-border);
     display: flex;
     justify-content: space-between;
@@ -30,12 +30,16 @@
 .item-title::after {
     width: 10px;
     height: 10px;
-    border-bottom: 2px solid #fff;
-    border-right: 2px solid #fff;
+    border-bottom: 2px solid var(--accordion-title-color);
+    border-right: 2px solid var(--accordion-title-color);
     transform-origin: 75% 75%;
     transform: rotate(-45deg) translateY(-50%);
     transition: transform .1s ease;
     content: '';
+}
+
+.item-title.open {
+    border-bottom: none;
 }
 
 .item-title.open::after {
@@ -57,4 +61,8 @@
 
 .item-title.open + .item-content {
     display: grid;
+}
+
+.item-title > div {
+    margin-left: 0;
 }

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -3,11 +3,13 @@
     --accordion-color: #57585a;
     --accordion-title-color: var(--accordion-color);
     --accordion-title-padding: 8px;
+    --accordion-title-font-size: 16px;
     --accordion-border-radius: 6px;
     --accordion-border-color: var(--accordion-color);
     --accordion-border: 1px solid var(--accordion-color);
     --accordion-content-background: #fff;
     --accordion-content-color: #56585a;
+    --accordion-content-font-size: 16px;
 }
 
 .accordion {
@@ -57,6 +59,7 @@
 
 .item-content > div {
     color: var(--accordion-content-color);
+    font-size: var(--accordion-content-font-size);
 }
 
 .item-title.open + .item-content {
@@ -65,4 +68,5 @@
 
 .item-title > div {
     margin-left: 0;
+    font-size: var(--accordion-title-font-size);
 }

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,11 +1,13 @@
 .accordion {
-    background: #EFEFEF;
+    background: #00808c;
+    color: #a7a7a7;
     border: 1px solid #ddd;
     border-radius: 6px;
 }
 
 .item-title {
     cursor: pointer;
+    color: #fff;
     padding: 12px;
     border-bottom: 1px solid #ddd;
     display: flex;
@@ -16,16 +18,12 @@
 .item-title::after {
     width: 10px;
     height: 10px;
-    border-bottom: 2px solid #a7a7a7;
-    border-right: 2px solid #a7a7a7;
+    border-bottom: 2px solid #fff;
+    border-right: 2px solid #fff;
     transform-origin: 75% 75%;
     transform: rotate(-45deg) translateY(-50%);
     transition: transform .1s ease;
     content: '';
-}
-
-.item-title.open {
-    background: #ddd;
 }
 
 .item-title.open::after {
@@ -37,7 +35,12 @@
     grid-template-columns: 1fr 1fr;
     gap: 12px;
     padding: 12px;
+    background: #ddd;
     border-bottom: 1px solid #ddd;
+}
+
+.item-content > div {
+    color: #56585a;
 }
 
 .item-title.open + .item-content {

--- a/blocks/search/search.css
+++ b/blocks/search/search.css
@@ -1,0 +1,31 @@
+:root {
+    --search-display: flex;
+    --search-button-height: 50px;
+    --search-button-width: 50px;
+    --search-button-padding: 8px;
+    --search-button-border-radius: 50%;
+    --search-input-border-radius: 50px;
+}
+
+.search-field {
+    display: var(--search-display);
+    flex-direction: row-reverse;
+    justify-content: center;
+    align-items: center;
+}
+
+.search-field .clear-results-button {
+    height: var(--search-button-height);
+    width: var(--search-button-width);
+    padding: var(--search-button-padding);
+    border-radius: var(--search-button-border-radius);
+}
+
+.search-field .search-input {
+    border-radius: var(--search-input-border-radius);
+}
+
+.search-field .clear-results-button,
+.search-field .search-input {
+    margin: 0;
+}


### PR DESCRIPTION
Basic updates to Accordion and Search Input CSS, using CSS variables and JS to modify/add classes to the HTML. I am referencing lovesac.com for the accordion styles. 

Here are the styles added:

<img width="1257" alt="Screenshot 2024-01-09 at 1 56 20 PM" src="https://github.com/tareddingatbaici/demo-lovesac-crosswalk/assets/100595568/0258eb7e-48a7-485a-bfdd-31d6b53eafac">


Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.page/
- After: https://<branch>--{repo}--{owner}.hlx.page/
